### PR TITLE
fix: avoid add quote for "on"

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -34,7 +34,7 @@ const YAMLParser = {
     return validateContent<T>(YAML.load(readFile(filePath)) as T, Format.YAML)
   },
   dump<T extends ContentNode>(content: T): string {
-    return YAML.dump(content, {lineWidth: -1})
+    return YAML.dump(content, {lineWidth: -1, noCompatMode: true})
   }
 }
 


### PR DESCRIPTION
fix #525 

warning: this will cause some incompatible issue with Yaml 1.1 and below.

Basically it won't put quote on the following values

'y', 'Y', 'yes', 'Yes', 'YES', 'on', 'On', 'ON', 'n', 'N', 'no', 'No', 'NO', 'off', 'Off', 'OFF'

